### PR TITLE
Fix return type of _call_eas to bytes as per issue #20453

### DIFF
--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -227,7 +227,7 @@ class PaiEasChatEndpoint(BaseChatModel):
                 f" and message {response.text}"
             )
 
-        return response.text
+        return response.content
 
     def _call_eas_stream(self, query_body: dict) -> Any:
         """Generate text from the eas service."""


### PR DESCRIPTION
This PR addresses the issue #20453 by changing the return type of the `_call_eas` method to `bytes` instead of `str`.