### PR TITLE
Fix return type of _call_eas to bytes as per issue #20453

### DIFF
--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -228,6 +228,25 @@ class PaiEasChatEndpoint(BaseChatModel):
             )
 
         return response.content
+        """Generate text from the eas service."""
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"{self.eas_service_token}",
+        }
+
+        # make request
+        response = requests.post(
+            self.eas_service_url, headers=headers, json=query_body, timeout=self.timeout
+        )
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Request failed with status code {response.status_code}"
+                f" and message {response.text}"
+            )
+
+        return response.content
 
     def _call_eas_stream(self, query_body: dict) -> Any:
         """Generate text from the eas service."""

--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -208,7 +208,7 @@ class PaiEasChatEndpoint(BaseChatModel):
 
         return generated_text
 
-    def _call_eas(self, query_body: dict) -> Any:
+    def _call_eas(self, query_body: dict) -> bytes:
         """Generate text from the eas service."""
         headers = {
             "Content-Type": "application/json",
@@ -227,7 +227,7 @@ class PaiEasChatEndpoint(BaseChatModel):
                 f" and message {response.text}"
             )
 
-        return response.text
+        return response.content
 
     def _call_eas_stream(self, query_body: dict) -> Any:
         """Generate text from the eas service."""


### PR DESCRIPTION
This pull request addresses issue #20453 by ensuring that the _call_eas method returns bytes type instead of str type.